### PR TITLE
Add usage to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ with full-paralelization, without respecting any particular order.
 Usage
 =====
 
-Program to list dependencies of a project, or to execute a command for each dependency:
+Program to list development dependencies of `conda-devenv` projects, or to execute a command for each dependency:
 
     deps [OPTIONS] [COMMAND]...
 
-To list dependency projects, one per line (if "-p directory" is omitted, it will use the current, or will find the first ancestor directory containing an `environment.devenv.yml` file):
+To list project dependencies of the project in the current directory, one per line:
+
+    deps
+
+It is possible to pass `-p directory` to find the first ancestor of `directory` containing an `environment.devenv.yml` file:
 
     deps -p mylib10 -p myotherlib20
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use deps to execute a command for each dependency (will spawn a new shell for
 
     deps [parameters] <command>
 
-To prevent deps to process any option or flags passed to command a "--" can be used
+To prevent deps to process any option or flags passed to command a "--" can be used:
 
     deps [parameters] -- <command> --with --flags
 
@@ -60,13 +60,8 @@ If the option --require-file is used dependencies not having a file named as thi
 
 When passing parameters that can be used multiple times through environment variable use the operational system path separator (windows=";", linux=":") to separate multiple entries:
 
-* Windows
-
-      set DEPS_IGNORE_PROJECT=old_project;fuzzy_project
-
-* Linux
-
-      export DEPS_IGNORE_PROJECT=old_project:fuzzy_project
+* Windows: `set DEPS_IGNORE_PROJECT=old_project;fuzzy_project`
+* Linux: `export DEPS_IGNORE_PROJECT=old_project:fuzzy_project`
 
 This is equivalent to pass `--ignore-project=old_project --ignore-project=fuzzy_project`.
 
@@ -81,11 +76,11 @@ Options Description:
     Project to find dependencies of (can be used multiple times).
 
   * `-pp, --pretty-print`
-  
+
     Pretty print dependencies in a tree.
 
   * `-f, --require-file TEXT`
-  
+
     Only run the command if the file exists (relative to dependency working directory).
 
   * `--here`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,120 @@ but respecting dependencies (so, it'll only run in parallel commands after their
 `deps inv codegen -j 16 --jobs-unordered` will run `inv codegen` on the projects and its dependencies
 with full-paralelization, without respecting any particular order.
 
+Usage
+=====
+
+Program to list dependencies of a project, or to execute a command for each dependency:
+
+    deps [OPTIONS] [COMMAND]...
+
+To list dependency projects, one per line (if "-p directory" is omitted, it will use the current, or will find the first ancestor directory containing an `environment.devenv.yml` file):
+
+    deps -p mylib10 -p myotherlib20
+
+This may be used in combination with shell commands (useful for `source`ing files), e.g., to iterate on dependencies in windows (cmd):
+
+    for %%i in ('deps -p mylib10') do <something> %%i [...]
+
+To iterate on dependencies in unix (bash):
+
+    deps | xargs -0 -I {} <something> {} [...]
+
+To use deps to execute a command for each dependency (will spawn a new shell for each dependency):
+
+    deps [parameters] <command>
+
+To prevent deps to process any option or flags passed to command a "--" can be used
+
+    deps [parameters] -- <command> --with --flags
+
+`<command>` may contain some variables:
+
+* {name}: The dependency bare name (ex.: eden)
+* {abs}:  The dependency absolute path (ex.: X:\ws\eden)
+
+If the option --require-file is used dependencies not having a file named as this relative to the given dependency root directory are skipped:
+
+    deps --require-file Makefile -- make clean
+
+When passing parameters that can be used multiple times through environment variable use the operational system path separator (windows=";", linux=":") to separate multiple entries:
+
+* Windows
+
+      set DEPS_IGNORE_PROJECT=old_project;fuzzy_project
+
+* Linux
+
+      export DEPS_IGNORE_PROJECT=old_project:fuzzy_project
+
+This is equivalent to pass `--ignore-project=old_project --ignore-project=fuzzy_project`.
+
+Options Description:
+
+  * `--version`
+
+    Show the version and exit.
+
+  * `-p, --project PATH`
+
+    Project to find dependencies of (can be used multiple times).
+
+  * `-pp, --pretty-print`
+  
+    Pretty print dependencies in a tree.
+
+  * `-f, --require-file TEXT`
+  
+    Only run the command if the file exists (relative to dependency working directory).
+
+  * `--here`
+
+    Do not change working dir.
+
+  * `-n, --dry-run`
+
+    Do not execute, only print what will be executed.
+
+  * `-v, --verbose`
+
+    Print more information.
+
+  * `--continue-on-failure`
+
+    Continue processing commands even when one fail (if some command fail the return value will be non zero).
+
+  * `-i, --ignore-project PATH`
+
+    Project name to ignore when looking for dependencies and will not recurse into those projects. Instead of passing this option an environment variable with the name `DEPS_IGNORE_PROJECT` can be used (can be used multiple times).
+
+  * `-s, --skip-project PATH`
+
+    Project name to skip execution but still look for its dependencies. Instead of passing this option an environment variable with the name `DEPS_SKIP_PROJECT` can be used (can be used multiple times).
+
+  * `--force-color / --no-force-color`
+
+    Always use colors on output (by default it is detected if running on a terminal). If file redirection is used ANSI escape sequences are output even on windows. Instead of passing this option an environment variable with the name `DEPS_FORCE_COLOR` can be used.
+
+  * `--repos`
+
+    Instead of projects the enumeration procedure will use the containing repositories instead of projects them selves.
+
+  * `-j, --jobs INTEGER`
+
+    Run commands in parallel using multiple processes.
+
+  * `--jobs-unordered`
+
+    Will run jobs without any specific order (useful if dependencies are not important and jobs > 1 to run more jobs concurrently).
+
+  * `--deps-reversed`
+
+    Will run with a reversed dependency (only used if --jobs=1). Useful to identify where the order is important.
+
+  * `--help`
+
+    Show this message and exit.
+
 License
 ========
 

--- a/source/python/deps/deps_cli.py
+++ b/source/python/deps/deps_cli.py
@@ -841,12 +841,15 @@ def cli(
     deps_reversed,
 ):
     """
-    Program to list dependencies of a project, or to execute a command for
-    each dependency.
+    Program to list development dependencies of `conda-devenv` projects, or to execute a command
+    for each dependency.
 
-    To list dependency projects, one per line (if "-p directory" is omitted,
-    it will use the current, or will find the first ancestor directory
-    containing an `environment.devenv.yml` file):
+    To list project dependencies of the project in the current directory, one per line:
+
+          deps
+
+      It is possible to pass `-p directory` to find the first ancestor of `directory` containing
+      an `environment.devenv.yml` file:
 
           deps -p mylib10 -p myotherlib20
 


### PR DESCRIPTION
The added usage is derived from `deps --help` and has been edited to get a better flow in markdown.

This is to improve the docs until #12 is not tackled.