### PR TITLE
[EDEN-2847] pixi-devenv support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.5.0 (UNRELEASED)
+------------------
+
+* `pixi-devenv <https://github.com/ESSS/pixi-devenv>` support added.
+
 1.4.0 (2024-07-03)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Deps is a utility to execute commands on multiple projects.
 
-It is meant to be used along with `conda devenv`: https://github.com/ESSS/conda-devenv, as such,
-it reads the contents of the `includes` sections of `environment.devenv.yml`, which contains
+It is meant to be used along with [conda devenv](https://github.com/ESSS/conda-devenv) and [pixi-devenv](https://github.com/ESSS/pixi-devenv), as such,
+it reads the contents of the `includes` sections of the `environment.devenv.yml` / `pixi.devenv.toml`, which contain
 the relative paths of the dependencies where commands should be executed.
 
 # Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "importlib-metadata>=8.7.0",
     "jinja2>=3.1",
     "pyyaml>=6.0.2",
+    "tomli>=2.2.1",
     "typing_extensions",
 ]
 
@@ -50,6 +51,7 @@ extend-select = [
     "UP",  # pyupgrade.
 ]
 ignore = [
+    "B011",  # Do not `assert False`
     "E501",  # Line too long
     "PLC0415", # `import` should be at the top-level of a file
     "PLR",  # Heuristics from pylint.

--- a/src/deps/deps_cli.py
+++ b/src/deps/deps_cli.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import click
 import importlib_metadata
-from typing_extensions import overload
+from typing_extensions import Self, overload
 
 from ._synchronous_executor import SynchronousExecutor
 
@@ -64,15 +64,10 @@ FILE_WITH_DEPENDENCIES = "environment.devenv.yml"
 
 
 @functools.cache
-def get_shallow_dependencies(
-    base_directory: str, filename: str | None = None
-) -> Sequence[tuple[str, str]]:
+def get_shallow_dependencies(dev_env_file: Path) -> Sequence[Path]:
     """
-    :param base_directory:
-        The project's root directory.
-    :param filename:
-        The environment definition file name. If `None` (or omitted)
-        `FILE_WITH_DEPENDENCIES` is used.
+    :param dev_env_file:
+        The environment definition file name.
     :return:
         The first level (does not recursively list dependencies of dependencies)
         dependencies of the project rooted in the given directory.
@@ -80,21 +75,15 @@ def get_shallow_dependencies(
     import jinja2
     import yaml
 
-    if filename is None:
-        filename = FILE_WITH_DEPENDENCIES
-
     # NOTE: From [conda-devenv](https://conda-devenv.readthedocs.io/en/latest/usage.html#jinja2)
-    jinja_args = {"root": base_directory, "os": os, "sys": sys, "platform": platform}
+    jinja_args = {"root": str(dev_env_file.parent), "os": os, "sys": sys, "platform": platform}
 
-    with open(os.path.join(base_directory, filename)) as f:
-        yaml_contents = jinja2.Template(f.read()).render(**jinja_args)
+    yaml_contents = jinja2.Template(dev_env_file.read_text(encoding="UTF-8")).render(**jinja_args)
 
     data = yaml.safe_load(yaml_contents) or {}
     if not data.get("includes"):
         return []
-    includes = [os.path.abspath(p) for p in data["includes"]]
-    includes = [(os.path.dirname(p), os.path.basename(p)) for p in includes]
-    return includes
+    return [Path(os.path.abspath(p)) for p in data["includes"]]
 
 
 @dataclass(eq=False)
@@ -102,7 +91,17 @@ class Dep:
     name: str
     abspath: str
     deps: list[Dep]
+
+    # Ignored projects:
+    # * Won't have commands executed in their root.
+    # * Dependencies are ignored.
     ignored: bool
+
+    # Skipped projects:
+    # * Won't have commands executed in their root.
+    # * Their dependencies are considered to be part of the hierarchy.
+    #
+    # `ignored` has higher priority than skipped, so if a project is skipped and ignored it is considered ignored.
     skipped: bool
 
     # Overridden to make identity compares.
@@ -112,27 +111,29 @@ class Dep:
     def __eq__(self, o: object) -> bool:
         return o is self
 
+    @classmethod
+    def from_directory(
+        cls, directory: str | Path, ignore_projects: list[str], skipped_projects: list[str]
+    ) -> Self:
+        """
+        :param directory:
+            Root directory of a project.
 
-def create_new_dep_from_directory(
-    directory: str | Path, ignore_projects: list[str], skipped_projects: list[str]
-) -> Dep:
-    """
-    :param directory: Root directory of a project.
-    :param ignore_projects: A list of project names to ignore (set the `ignored` attr
-    to `True`).
-    :param skipped_projects: A list of project names that should be skipped i.e. they
-    are part of dependencies but they aren't executed. Skipped has less priority than ignored, so
-    if a name is in both lists it will be always ignored.
-    """
-    directory = os.path.abspath(directory)
-    name = os.path.split(directory)[1]
-    return Dep(
-        name=name,
-        abspath=directory,
-        deps=[],
-        ignored=name in ignore_projects,
-        skipped=name in skipped_projects,
-    )
+        :param ignore_projects:
+            A list of project names to ignore (sets `ignored` to `True` if this Dep is in that list).
+
+        :param skipped_projects:
+            A list of project names to skip (sets `skipped` to `True` if this Dep is in that list).
+        """
+        directory = os.path.abspath(directory)
+        name = os.path.basename(directory)
+        return cls(
+            name=name,
+            abspath=directory,
+            deps=[],
+            ignored=name in ignore_projects,
+            skipped=name in skipped_projects,
+        )
 
 
 def pretty_print_dependency_tree(root_deps: list[Dep]) -> None:
@@ -246,32 +247,27 @@ def obtain_all_dependencies_recursively(
     all_deps = {}
 
     def add_deps_from_directories(
-        directories: Sequence[tuple[str, str | None]], list_to_add_deps: list[Dep]
+        dev_env_files: Sequence[Path], list_to_add_deps: list[Dep]
     ) -> None:
         """
-        A data structure (`Dep`) is created for each project rooted in the given directories.
-
-        :param sequence(tuple(unicode,unicode)) directories: Projects' roots to use.
-        :param list(Dep) list_to_add_deps: A list to be populated with the created `Dep`s
-        processed `Dep`s (in case multiple projects have the same dependency).
+        Create `Dep` for each devenv file found, recursively, and add them to `list_to_add_deps`.
         """
-        for dep_directory, dep_env_filename in directories:
+        for dev_env_file in dev_env_files:
+            dep_directory = dev_env_file.parent
             if dep_directory not in all_deps:
-                dep = create_new_dep_from_directory(
-                    dep_directory, ignored_projects, skipped_projects
-                )
+                dep = Dep.from_directory(dep_directory, ignored_projects, skipped_projects)
                 all_deps[dep_directory] = dep
                 if not dep.ignored:
-                    current_dep_directories = get_shallow_dependencies(
-                        dep_directory, dep_env_filename
-                    )
+                    current_dep_directories = get_shallow_dependencies(dev_env_file)
                     add_deps_from_directories(current_dep_directories, dep.deps)
             else:
                 dep = all_deps[dep_directory]
             list_to_add_deps.append(dep)
 
     root_deps: list[Dep] = []
-    add_deps_from_directories([(p, None) for p in root_directories], root_deps)
+    add_deps_from_directories(
+        [Path(p, FILE_WITH_DEPENDENCIES) for p in root_directories], root_deps
+    )
     return root_deps
 
 
@@ -279,7 +275,7 @@ def obtain_repos(dep_list: list[Dep]) -> list[Dep]:
     """
     Obtain the repos for the given projects and their dependencies.
     """
-    all_repos: dict[tuple[str | None, bool], Dep] = {}
+    all_repos: dict[tuple[str, bool], Dep] = {}
 
     def obtain_repo_from_dep(dep: Dep) -> Dep:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,7 @@ dependencies = [
     { name = "importlib-metadata" },
     { name = "jinja2" },
     { name = "pyyaml" },
+    { name = "tomli" },
     { name = "typing-extensions" },
 ]
 
@@ -60,6 +61,7 @@ requires-dist = [
     { name = "importlib-metadata", specifier = ">=8.7.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "tomli", specifier = ">=2.2.1" },
     { name = "typing-extensions" },
 ]
 


### PR DESCRIPTION
Support for [pixi-devenv](https://github.com/ESSS/pixi-devenv) files.

The support needed by `deps` is minimal, just the `includes` directive for now.