### PR TITLE
Fixes #69: Add support to Python 3.13+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+* Support Python 3.13+ by dropping usage of `pipes` module, which has since then been removed.
+
 1.6.0 (2025-11-19)
 ------------------
 

--- a/src/deps/deps_cli.py
+++ b/src/deps/deps_cli.py
@@ -749,10 +749,10 @@ def execute(
         A tuple with (returncode, stdout, stderr, time to execute command).
     """
     if not sys.platform.startswith("win"):
-        import pipes
+        import shlex
 
         for index, item in enumerate(formatted_command):
-            formatted_command[index] = pipes.quote(item)
+            formatted_command[index] = shlex.quote(item)
         command = " ".join(formatted_command)
     else:
         command = formatted_command


### PR DESCRIPTION
- Drop the usage of "pipes" since it was removed in Python 3.13 and replace it by shlex